### PR TITLE
Add 3x std normalization for CIFAR

### DIFF
--- a/target_prop/config.py
+++ b/target_prop/config.py
@@ -25,6 +25,7 @@ from torchvision.transforms import (
 from target_prop.datasets import (
     CIFAR10DataModule,
     ImageNet32DataModule,
+    cifar10_3xstd_normalization,
     cifar10_normalization,
     imagenet32_normalization,
 )
@@ -39,10 +40,12 @@ class Config(Serializable):
 
     available_datasets: ClassVar[Dict[str, Type[LightningDataModule]]] = {
         "cifar10": CIFAR10DataModule,
+        "cifar10_3xstd": CIFAR10DataModule,
         "imagenet32": ImageNet32DataModule,
     }
     normalization_transforms: ClassVar[Dict[str, Callable[[], Transform]]] = {
         "cifar10": cifar10_normalization,
+        "cifar10_3xstd": cifar10_3xstd_normalization,
         "imagenet32": imagenet32_normalization,
     }
 

--- a/target_prop/datasets/cifar10_datamodule.py
+++ b/target_prop/datasets/cifar10_datamodule.py
@@ -15,6 +15,11 @@ def cifar10_normalization():
     #     mean=[x / 255.0 for x in [125.3, 123.0, 113.9]],
     #     std=[x / 255.0 for x in [63.0, 62.1, 66.7]],
     # )
+    normalize = transforms.Normalize(mean=(0.4914, 0.4822, 0.4465), std=(0.2023, 0.1994, 0.2010))
+    return normalize
+
+
+def cifar10_3xstd_normalization():
     normalize = transforms.Normalize(
         mean=(0.4914, 0.4822, 0.4465), std=(3 * 0.2023, 3 * 0.1994, 3 * 0.2010)
     )


### PR DESCRIPTION
This is a quick solution to allow using 3x std normalization in CIFAR10 dataset without changing code structure.

To use 3x std normalization, use `--dataset cifar10_3xstd` instead of `--dataset cifar10`:
```
python main_pl.py run backdrop simple_vgg --dataset cifar10_3xstd <custom args>
```