### PR TITLE
Add top5 metric

### DIFF
--- a/main_pl.py
+++ b/main_pl.py
@@ -164,9 +164,11 @@ def run(
     test_results = trainer.test(model, datamodule=datamodule, verbose=True)
 
     wandb.finish()
-    test_accuracy: float = test_results[0]["test/accuracy"]
-    print(f"Test accuracy: {test_accuracy:.1%}")
-    return test_accuracy
+    top1_accuracy: float = test_results[0]["test/accuracy"]
+    top5_accuracy: float = test_results[0]["test/top5_accuracy"]
+    print(f"Test top1 accuracy: {top1_accuracy:.1%}")
+    print(f"Test top5 accuracy: {top5_accuracy:.1%}")
+    return top1_accuracy, top5_accuracy
 
 
 def add_sweep_args(parser: ArgumentParser):

--- a/target_prop/models/dtp.py
+++ b/target_prop/models/dtp.py
@@ -296,7 +296,7 @@ class DTP(LightningModule):
                     assert iterations == 0
         # Metrics:
         self.accuracy = Accuracy()
-
+        self.top5_accuracy = Accuracy(top_k=5)
         self.save_hyperparameters(
             {
                 "hp": self.hp.to_dict(),
@@ -642,8 +642,9 @@ class DTP(LightningModule):
 
             # self.trainer is None in some unit tests which only use PL module
             if self.trainer is not None:
-                accuracy = self.accuracy(torch.softmax(logits, -1), labels)
-                self.log(f"{phase}/accuracy", accuracy, prog_bar=True)
+                probs = torch.softmax(logits, -1)
+                self.log(f"{phase}/accuracy", self.accuracy(probs, labels), prog_bar=True)
+                self.log(f"{phase}/top5_accuracy", self.top5_accuracy(probs, labels))
 
             temp_logits = logits.detach().clone()
             temp_logits.requires_grad_(True)


### PR DESCRIPTION
Also, fixed a minor bug in LR logging:

Remove LR logging in test mode. Optimizer is not configured while testing, so logging raises an error when model is directly tested without calling `.fit()` method.